### PR TITLE
Add Kolors Virtual to Demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,7 @@ A curated list of awesome research papers, projects, code, datasets, workshops, 
 - Genlook virtual try-on for Ecommerce ( Garment, shoes, glasses ). [Business](https://www.genlook.app/) [Demo](https://demo.genlook.app/products/t-shirt-manches-courtes-imprime)
 - Adstronaut AI - on-model AI photoshoots, garment editor, color and fabric swap, and tech packs for fashion brands. [Business](https://adstronaut.net)
 - STIL.AI - AI-powered fashion design generator. Describe your dream garment and get a unique AI-generated design in seconds. Free preview with watermark, high-res purchase from 9 SEK. [Demo](https://stil.gracestack.se/text-till-mode.html), [Business](https://stil.gracestack.se)
+- Kolors Virtual - AI fashion virtual try-on that generates images and videos of models wearing your outfits. [Business/Demo](https://www.kolorsvirtual.com/)
 
 
 


### PR DESCRIPTION
Adds Kolors Virtual to the Demos section, alongside other hosted fashion try-on products (Looklet, Genlook, Virtual Try On AI).

- Kolors Virtual — AI fashion virtual try-on that generates images and videos of models wearing your outfits.
- Official URL: https://www.kolorsvirtual.com/ (live, 200)

Affiliation: I am the founder of Kolors Virtual.